### PR TITLE
fix(security): cerrar IDOR en controllers y endurecer sanitización de…

### DIFF
--- a/app/controllers/announcement_comments_controller.rb
+++ b/app/controllers/announcement_comments_controller.rb
@@ -31,7 +31,7 @@ class AnnouncementCommentsController < ApplicationController
   end
 
   def set_context
-    @project = Project.find(params[:project_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
     @announcement = @project.announcements.find(params[:announcement_id])
   end
 end

--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -47,7 +47,7 @@ class AnnouncementsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
   end
 
   def announcement_params

--- a/app/controllers/columns_controller.rb
+++ b/app/controllers/columns_controller.rb
@@ -81,7 +81,7 @@ class ColumnsController < ApplicationController
   private
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
   end
 
   def set_board

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -42,9 +42,9 @@ class CommentsController < ApplicationController
   private
 
   def set_context
-    @project = Project.find(params[:project_id])
-    @todo = Todo.find(params[:todo_id])
-    @task = Task.find(params[:task_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
+    @todo = @project.todos.find(params[:todo_id])
+    @task = @todo.tasks.find(params[:task_id])
   end
 
   def set_comment

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -107,15 +107,17 @@ class DocumentsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_document
-      @document = Document.find(params.expect(:id))
+      @document = Document.joins(project: :project_users)
+                          .where(project_users: { user_id: current_user.id })
+                          .find(params.expect(:id))
     end
 
     def set_project
-      @project = Project.find(params[:project_id])
+      @project = Project.for_user(current_user).find(params[:project_id])
     end
 
     def set_folder
-      @folder = params[:folder_id].present? ? Folder.find(params[:folder_id]) : nil
+      @folder = params[:folder_id].present? ? @project.folders.find(params[:folder_id]) : nil
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -58,15 +58,15 @@ class FoldersController < ApplicationController
   private
 
   def set_folder
-    @folder = Folder.find(params[:id])
+    @folder = @project.folders.find(params[:id])
   end
 
   def set_project
-    @project = Project.find(params[:project_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
   end
 
   def set_parent_folder
-    @parent_folder = params[:parent_folder_id].present? ? Folder.find(params[:parent_folder_id]) : nil
+    @parent_folder = params[:parent_folder_id].present? ? @project.folders.find(params[:parent_folder_id]) : nil
   end
 
   def folder_params

--- a/app/controllers/task_assignments_controller.rb
+++ b/app/controllers/task_assignments_controller.rb
@@ -3,7 +3,7 @@ class TaskAssignmentsController < ApplicationController
   before_action :set_task
 
   def create
-    @user = User.find(params[:user_id])
+    @user = @project.users.find(params[:user_id])
     @assignment = @task.task_assignments.new(user: @user)
 
     if @assignment.save
@@ -39,13 +39,12 @@ class TaskAssignmentsController < ApplicationController
   end
 
   def search
-    project = @task.todo.project
     query = params[:query].to_s.downcase
 
     # Buscar usuarios del proyecto que no estén ya asignados
     assigned_user_ids = @task.assigned_users.pluck(:id)
 
-    users = project.users
+    users = @project.users
       .where.not(id: assigned_user_ids)
       .where("LOWER(first_name) LIKE ? OR LOWER(last_name) LIKE ? OR LOWER(email) LIKE ?",
              "%#{query}%", "%#{query}%", "%#{query}%")
@@ -57,6 +56,8 @@ class TaskAssignmentsController < ApplicationController
   private
 
   def set_task
-    @task = Task.find(params[:task_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
+    @todo = @project.todos.find(params[:todo_id])
+    @task = @todo.tasks.find(params[:task_id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,17 +1,13 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_context, except: :my_task
+  before_action :set_task, only: %i[show edit update destroy add_comment search_members]
 
   def index
     @tasks = @todo.tasks
   end
 
   def show
-    @task = Task.includes(:assigned_users, :created_by, :publication, comments: :user).find(params[:id])
-    @todo = Todo.find(params[:todo_id])
-    @project = Project.find(params[:project_id])
-  rescue ActiveRecord::RecordNotFound
-    redirect_to project_todos_path(params[:project_id]), alert: "La tarea que buscas no existe o fue eliminada."
   end
 
   def new
@@ -31,12 +27,9 @@ class TasksController < ApplicationController
   end
 
   def edit
-    @task = Task.find(params[:id])
   end
+
   def update
-    @task = Task.find(params[:id])
-    logger.debug "params: #{params.inspect}"
-    logger.debug "params: #{tasks_params}"
     if @task.update(tasks_params)
       if params[:from] == "full_form" || params[:from] == "show"
         redirect_to project_todo_task_path(@project, @todo, @task), notice: "Tarea actualizada correctamente."
@@ -49,7 +42,6 @@ class TasksController < ApplicationController
   end
 
   def add_comment
-    @task = Task.find(params[:id])
     @comment = @task.comments.new(comment_params)
     @comment.user = current_user
     if @comment.save
@@ -64,7 +56,6 @@ class TasksController < ApplicationController
   end
 
   def destroy
-    @task = Task.find(params[:id])
     @task.destroy
     redirect_to project_todos_path(@project), notice: "Task has been deleted successfully."
   end
@@ -84,9 +75,6 @@ class TasksController < ApplicationController
   end
 
   def search_members
-    @task = Task.find(params[:id])
-    @project = @task.todo.project
-
     query = params[:q].to_s.downcase
 
     users = @project.users.where(
@@ -109,9 +97,18 @@ class TasksController < ApplicationController
   private
 
   def set_context
-    @todo = Todo.find(params[:todo_id])
-    @project = Project.find(params[:project_id])
+    @project = Project.for_user(current_user).find(params[:project_id])
+    @todo = @project.todos.find(params[:todo_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to projects_path, alert: "El recurso solicitado no existe o no tienes acceso."
   end
+
+  def set_task
+    @task = @todo.tasks.includes(:assigned_users, :created_by, :publication, comments: :user).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to project_todos_path(@project), alert: "La tarea que buscas no existe o fue eliminada."
+  end
+
   def tasks_params
     params.require(:task).permit(:title, :completed, :status, :from, :notes, :due_date, :column_id)
   end

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -58,7 +58,7 @@ class TodosController < ApplicationController
 
     private
     def set_project
-      @project = Project.find(params[:project_id])
+      @project = Project.for_user(current_user).find(params[:project_id])
     end
 
     def set_todo

--- a/docs/analisis-de-vulnerabilidades.md
+++ b/docs/analisis-de-vulnerabilidades.md
@@ -1,0 +1,345 @@
+# Análisis de vulnerabilidades — Tivo
+
+Fecha del análisis: 2026-05-20
+Branch: `feat/javiermora/tenant_config`
+Herramientas usadas: revisión manual + `bin/brakeman` (0 warnings — el escáner estático no detecta lógica de autorización, que es donde la app tiene los problemas serios).
+
+## Resumen ejecutivo
+
+El patrón dominante es **broken access control / IDOR**: la tenancy se "confía" al `params[:project_id]` sin verificar membership, y los nested resources (`Task`, `Folder`, `Document`, `Comment`) se cargan con `Model.find(params[:id])` sin scoping al project. La gema `acts_as_tenant` resolvería esto estructuralmente, pero conviene cerrar primero los huecos de autorización para no enmascarar bugs durante la migración.
+
+| Severidad | Total | Resueltos | Pendientes |
+|-----------|-------|-----------|------------|
+| Crítica   | 8     | 5         | 3          |
+| Alta      | 9     | 0         | 9          |
+| Media     | 5     | 0         | 5          |
+| Baja      | 3     | 0         | 3          |
+
+## Estado por hallazgo
+
+| ID | Severidad | Categoría | Título | Estado |
+|----|-----------|-----------|--------|--------|
+| C1 | Crítica | Access Control | IDOR: `Project.find` sin validar membership en 8 controllers | ✅ Resuelto (2026-05-20) |
+| C2 | Crítica | Access Control | IDOR en `Task.find` directo | ✅ Resuelto (2026-05-20) |
+| C3 | Crítica | Access Control | IDOR en `Folder.find` (incluye `parent_folder_id`) | ✅ Resuelto (2026-05-20) |
+| C4 | Crítica | Access Control | IDOR en download/duplicate/archive de Document | ✅ Resuelto (2026-05-20) |
+| C5 | Crítica | Authorization | Un member puede eliminar el project completo | ⏳ Pendiente |
+| C6 | Crítica | Authorization | Un member puede expulsar a otros members | ⏳ Pendiente |
+| C7 | Crítica | CSRF + IDOR | `board_tasks#update_position` sin CSRF ni scoping | ⏳ Pendiente |
+| C8 | Crítica | XSS | SVG sanitizer custom incompleto | ✅ Resuelto (2026-05-20) |
+| A1 | Alta | Tokens | Invitation tokens sin expiración ni rotación | ⏳ Pendiente |
+| A2 | Alta | Rate limiting | Sin `Rack::Attack` | ⏳ Pendiente |
+| A3 | Alta | Mass assignment | `column_id` en `tasks_params` sin validar | ⏳ Pendiente |
+| A4 | Alta | Mass assignment | `parent_folder_id` en `folder_params` sin validar | ⏳ Pendiente |
+| A5 | Alta | File upload | Validación de avatar por `content_type` (spoofeable) | ⏳ Pendiente |
+| A6 | Alta | File upload | Documentos sin allowlist de tipos ni límite | ⏳ Pendiente |
+| A7 | Alta | Secrets | Password de DB con default hardcoded | ⏳ Pendiente |
+| A8 | Alta | Defense in depth | CSP deshabilitada | ⏳ Pendiente |
+| A9 | Alta | Auth | OmniAuth vincula por email sin verificar `email_verified` | ⏳ Pendiente |
+| M1 | Media | Authorization | `regenerate_invitation` sin `return` tras check fallido | ⏳ Pendiente |
+| M2 | Media | Info disclosure | `logger.debug` con `params.inspect` | ⏳ Pendiente |
+| M3 | Media | Session | Cookie `rememberable` sin flags explícitos | ⏳ Pendiente |
+| M4 | Media | XSS | Action Text en email de announcements | ⏳ Pendiente |
+| M5 | Media | Crypto | Lookup de invitation_token no usa comparación constant-time | ⏳ Pendiente |
+| B1 | Baja | Dependencias | `omniauth-google-oauth2` sin pin de versión | ⏳ Pendiente |
+| B2 | Baja | Tooling | Brakeman desactualizado (7.1.0 → 8.0.4) | ⏳ Pendiente |
+| B3 | Baja | Tooling | Sin `bundler-audit` / `dependabot` | ⏳ Pendiente |
+
+---
+
+## Hallazgos detallados
+
+### Críticas
+
+#### C1. IDOR masivo: `Project.find(params[:project_id])` sin validar membership
+
+**Ubicaciones**
+- `app/controllers/documents_controller.rb:114`
+- `app/controllers/folders_controller.rb:65`
+- `app/controllers/todos_controller.rb:61`
+- `app/controllers/tasks_controller.rb:113`
+- `app/controllers/announcements_controller.rb:50`
+- `app/controllers/announcement_comments_controller.rb:34`
+- `app/controllers/columns_controller.rb:84`
+- `app/controllers/comments_controller.rb:45`
+
+```ruby
+def set_project
+  @project = Project.find(params[:project_id])
+end
+```
+
+**Por qué**: cualquier usuario autenticado, conociendo un `project_id`, accede a recursos del project ajeno.
+
+**Explotación**: `GET /projects/999/folders` lista carpetas de un project del que el atacante no es miembro.
+
+**Fix**: usar `Project.for_user(current_user).find(params[:project_id])`. Devuelve 404 (`ActiveRecord::RecordNotFound`) si el user no es miembro, igual que pasa con un id inexistente — sin filtrado de información.
+
+---
+
+#### C2. IDOR en `Task.find(params[:id])` directo
+
+**Ubicaciones**: `app/controllers/tasks_controller.rb:10, 34, 37, 52, 67, 87` y `app/controllers/task_assignments_controller.rb:60`.
+
+```ruby
+@task = Task.includes(...).find(params[:id])
+```
+
+**Por qué**: aunque el `@project` esté scopeado, la tarea se carga sin validar que pertenezca al project. `PATCH /projects/1/todos/1/tasks/999` edita la tarea 999 sin importar a qué project pertenezca.
+
+**Fix**: cargar desde la asociación: `@task = @todo.tasks.find(params[:id])`.
+
+---
+
+#### C3. IDOR en `Folder.find` (incluye `parent_folder_id`)
+
+**Ubicaciones**: `app/controllers/folders_controller.rb:61, 69`.
+
+```ruby
+def set_folder
+  @folder = Folder.find(params[:id])
+end
+
+def set_parent_folder
+  @parent_folder = params[:parent_folder_id].present? ? Folder.find(params[:parent_folder_id]) : nil
+end
+```
+
+**Por qué**: permite mover folders entre projects ajenos o anidar bajo un parent_folder ajeno.
+
+**Fix**: cargar desde `@project.folders.find(...)`.
+
+---
+
+#### C4. IDOR en download/duplicate/archive de Document
+
+**Ubicaciones**: `app/controllers/documents_controller.rb:72-105` + `set_document` en `:110`.
+
+```ruby
+def set_document
+  @document = Document.find(params.expect(:id))
+end
+```
+
+**Por qué**: `GET /documents/:id/download` entrega el blob sin verificar project ownership.
+
+**Fix**: cargar el documento via join con projects accesibles:
+```ruby
+@document = Document.joins(project: :project_users)
+                    .where(project_users: { user_id: current_user.id })
+                    .find(params.expect(:id))
+```
+
+---
+
+#### C5. Un member puede eliminar el project completo
+
+**Ubicación**: `app/controllers/projects_controller.rb:74-78`.
+
+```ruby
+def destroy
+  @project = Project.for_user(current_user).find(params[:id])
+  @project.destroy
+end
+```
+
+`for_user` incluye members. No hay check de `role == "owner"`.
+
+**Explotación**: un member hace `DELETE /projects/:id` y elimina todo (con `dependent: :destroy` se llevan todos los todos, tasks, documents, announcements, etc.).
+
+**Fix**: introducir una policy (Pundit u objeto simple) que valide `project.owner == current_user` en `destroy`, `archive`, `unarchive`, `update`.
+
+---
+
+#### C6. Un member puede expulsar a otros members
+
+**Ubicación**: `app/controllers/project_members_controller.rb:38-49`.
+
+Solo se valida que el target no sea owner, no que **quien borra** sea owner.
+
+**Fix**: agregar verificación `unless current_user == @project.owner`.
+
+---
+
+#### C7. CSRF bypass + IDOR combinados en `board_tasks#update_position`
+
+**Ubicación**: `app/controllers/board_tasks_controller.rb:3`.
+
+```ruby
+skip_before_action :verify_authenticity_token, only: [:update_position]
+def update_position
+  task = Task.find(params[:id])
+  column = Column.find(params[:column_id])
+  task.update(column: column, position: params[:position].to_i)
+end
+```
+
+**Explotación**: un sitio externo puede mover tareas de cualquier usuario logueado, a cualquier columna existente.
+
+**Fix**: quitar el `skip`, o si el cliente JS no envía CSRF token, agregarlo. Scopear `task` y `column` por project del current_user.
+
+---
+
+#### C8. XSS persistente vía SVG inline
+
+**Ubicación**: `app/helpers/documents_helper.rb:71-81` + `lib/svg_sanitizer.rb` + `config/initializers/active_storage.rb:36-37`.
+
+El `SvgSanitizer` custom remueve `<script>`, `<foreignobject>` y atributos `on*`/`href:javascript:`, pero **no cubre**:
+- `<style>` con `@keyframes` y URLs `javascript:`
+- `<animate attributeName="href" to="javascript:...">`
+- `<set>` con atributos peligrosos
+- `<use href="#x">` con xlink a externos
+
+Combinado con C1 (IDOR), un no-miembro puede subir el SVG si conoce un `project_id`.
+
+**Fix**: reescribir el sanitizer con **allowlist** de tags y atributos (en vez de blocklist) usando Loofah con un scrubber custom.
+
+---
+
+### Altas
+
+#### A1. Invitation tokens sin expiración ni rotación
+`Project#invitation_token` se genera una vez y vive para siempre. Si se filtra (Slack, screenshot), acceso permanente.
+**Fix**: agregar `invitation_token_expires_at`, rotación opcional post-uso, y endpoint para revocar.
+
+#### A2. Sin rate limiting
+No hay `rack-attack` en Gemfile. Vulnerable a bruteforce de login, enumeración de invitation tokens, spam de invitaciones.
+**Fix**: agregar `gem "rack-attack"` con throttles por IP/user en login, password reset, signup, invitaciones.
+
+#### A3. `column_id` en `tasks_params` sin validar pertenencia
+`app/controllers/tasks_controller.rb:116`. Combinado con C2, permite mover tareas a columnas ajenas.
+**Fix**: validar en el modelo `Task` que `column.board.project_id == todo.project_id`.
+
+#### A4. `parent_folder_id` en `folder_params` sin validar pertenencia
+`app/controllers/folders_controller.rb:73`. Permite anidar folder bajo parent de otro project, o crear ciclos.
+**Fix**: validación en el modelo `Folder` que `parent_folder.project_id == project_id`.
+
+#### A5. Validación de avatar por `content_type` (spoofeable)
+`app/controllers/profiles_controller.rb:30-34` confía en el header HTTP. Sin magic bytes.
+**Fix**: usar `marcel` (ya viene con Active Storage) para detección por contenido real.
+
+#### A6. Documentos sin allowlist de tipos ni límite
+`app/controllers/documents_controller.rb:123` permite `:file` sin validación.
+**Fix**: validación en el modelo `Document` (content_type + tamaño + magic bytes).
+
+#### A7. Password de DB con default hardcoded
+`config/database.yml`: `ENV.fetch("DB_PASSWORD") { "expressativo" }` en 7 sitios.
+**Fix**: `ENV.fetch("DB_PASSWORD")` sin default. Que falle ruidoso si no se setea.
+
+#### A8. CSP deshabilitada
+`config/initializers/content_security_policy.rb` todo comentado. Sin defense-in-depth para C8.
+**Fix**: habilitar CSP con `default-src 'self'`, `script-src 'self' 'nonce-...'`, prohibir inline.
+
+#### A9. OmniAuth vincula por email sin verificar `email_verified`
+`app/models/user.rb:22-43`. Hoy Google verifica email, pero al añadir otros providers → account takeover trivial.
+**Fix**: verificar `auth.info.email_verified` antes de vincular.
+
+---
+
+### Medias
+
+#### M1. `regenerate_invitation` sin `return` tras check fallido
+`app/controllers/project_invitations_controller.rb:45`. Hoy no causa daño pero el patrón es frágil.
+
+#### M2. `logger.debug` con `params.inspect`
+`app/controllers/tasks_controller.rb:38-39`. Filtra params completos en logs si log_level es debug.
+
+#### M3. Cookie `rememberable` sin flags explícitos
+`config/initializers/devise.rb:170`. Fijar `secure: true, httponly: true, same_site: :lax` explícitamente.
+
+#### M4. Action Text en email de announcements
+`app/views/announcement_mailer/new_announcement_notification.html.erb:73`. Validar que la sanitización de Action Text no permite `<style>` ni `on*` en emails.
+
+#### M5. Lookup de invitation_token no usa comparación constant-time
+`Project.find_by(invitation_token: params[:token])`. Bajo riesgo con tokens de 256 bits, pero notable.
+
+---
+
+### Bajas
+
+#### B1. `omniauth-google-oauth2` sin pin de versión
+Riesgo de supply-chain en `bundle update`.
+
+#### B2. Brakeman desactualizado (7.1.0 → 8.0.4)
+Falsos negativos por reglas viejas.
+
+#### B3. Sin `bundler-audit` / `dependabot`
+No detecta CVEs nuevas en gems.
+
+---
+
+## Plan de remediación
+
+Orden sugerido por relación impacto/riesgo:
+
+1. **C1 + C2 + C3 + C4** — Bloquear el sangrado de tenancy. PRs pequeños, sin migraciones.
+2. **C5 + C6 + M1** — Policies por rol (owner vs member).
+3. **C7** — CSRF + scoping en board_tasks.
+4. **C8** — Reemplazar SvgSanitizer por Loofah con allowlist.
+5. **A1** — TTL y rotación de invitation tokens.
+6. **A2** — Rack::Attack.
+7. **A3 + A4** — Validaciones de pertenencia en modelos.
+8. **A5 + A6** — Validación real de archivos (magic bytes).
+9. **A7** — Sacar defaults de credenciales.
+10. **A8** — Habilitar CSP.
+11. **A9** — Verificar `email_verified` en OmniAuth.
+12. **M2 + M3 + M4 + M5** — Limpieza.
+13. **B1 + B2 + B3** — Tooling de seguridad continua.
+14. **Migrar a `acts_as_tenant`** — una vez 1-3 estén hechos, la gema se vuelve cleanup.
+
+---
+
+## Changelog
+
+> Esta sección se actualiza a medida que los hallazgos se solucionan. Cada entrada incluye fecha, hallazgo y commit/PR.
+
+### 2026-05-20
+
+**C1 — IDOR en `set_project` (8 controllers)** ✅
+Reemplazado `Project.find(params[:project_id])` por `Project.for_user(current_user).find(...)` en:
+- `app/controllers/documents_controller.rb`
+- `app/controllers/folders_controller.rb`
+- `app/controllers/todos_controller.rb`
+- `app/controllers/tasks_controller.rb` (en `set_context`)
+- `app/controllers/announcements_controller.rb`
+- `app/controllers/announcement_comments_controller.rb`
+- `app/controllers/columns_controller.rb`
+- `app/controllers/comments_controller.rb`
+
+Ahora un usuario que no es miembro del project recibe 404 en lugar de poder operar sobre recursos ajenos.
+
+**C2 — IDOR en `Task.find` directo** ✅
+- `app/controllers/tasks_controller.rb`: extraído `set_task` que carga via `@todo.tasks.find(params[:id])`. Eliminadas las re-asignaciones de `@project`/`@todo` en `show` que pisaban el scoping.
+- `app/controllers/task_assignments_controller.rb` (no estaba en la lista original pero tenía el mismo patrón): `set_task` ahora carga `@project → @todo → @task` desde asociaciones. `create` también scopea `@user = @project.users.find(...)` para evitar asignar usuarios externos al project.
+
+**C3 — IDOR en `Folder.find` y `parent_folder_id`** ✅
+`app/controllers/folders_controller.rb`: `set_folder` y `set_parent_folder` ahora cargan desde `@project.folders.find(...)`. `documents_controller#set_folder` también.
+
+**C4 — IDOR en download/duplicate/archive de Document** ✅
+`app/controllers/documents_controller.rb#set_document` ahora hace:
+```ruby
+Document.joins(project: :project_users)
+        .where(project_users: { user_id: current_user.id })
+        .find(params.expect(:id))
+```
+Un user que no es miembro del project del documento recibe 404, lo que cierra `download`, `duplicate`, `archive`, `show`, `edit`, `update`, `destroy`.
+
+**C8 — SVG sanitizer custom incompleto** ✅
+`lib/svg_sanitizer.rb` reescrito con Loofah + scrubber custom usando **allowlist** estricto de tags SVG seguros (sin `<style>`, `<foreignObject>`, ni `<script>`) y filtrado de atributos `on*` y `href`/`xlink:href` con esquemas peligrosos.
+
+Vectores verificados manualmente como bloqueados:
+- `<script>` → eliminado
+- `onclick="alert(1)"` → atributo eliminado
+- `<a href="javascript:alert(1)">` → tag eliminado (`<a>` no está en allowlist)
+- `<foreignObject><iframe src="javascript:..."/>` → eliminado
+- `<style>circle { fill: url(javascript:...); }</style>` → tag `<style>` eliminado
+- `<animate attributeName="href" to="javascript:...">` → eliminado (`<a>` envolvente no en allowlist)
+- `<use xlink:href="javascript:...">` → atributo eliminado
+
+SVG legítimos (con `<circle>`, `<rect>`, gradientes, filtros, etc.) se renderizan sin cambios.
+
+### Notas
+
+- **Tests no se pudieron correr**: `config/database.yml` no especifica `adapter` para `test.primary`, error preexistente (`ActiveRecord::AdapterNotSpecified`) que no introdujeron estos cambios. Verificación se hizo con `bin/rails runner` cargando los controllers y ejercitando `SvgSanitizer` contra 9 vectores conocidos. `bin/rubocop` pasa limpio en los 10 archivos modificados.
+- **Vulnerabilidad lateral arreglada de paso**: `TaskAssignmentsController` tenía el mismo patrón C2/IDOR y fue corregido aunque no estaba en la lista original.
+- **Acceso a usuarios externos**: `TaskAssignmentsController#create` ahora valida que el assignee sea miembro del project (antes hacía `User.find(params[:user_id])` permitiendo asignar a cualquier usuario del sistema).

--- a/lib/svg_sanitizer.rb
+++ b/lib/svg_sanitizer.rb
@@ -1,51 +1,82 @@
-require "nokogiri"
+require "loofah"
+require "set"
 
-# Sanitiza contenido SVG para poder embeberlo inline en el HTML.
-# Elimina vectores de XSS: <script>, <foreignObject>, atributos on*, href/xlink:href
-# con esquemas peligrosos (javascript:, data: que no sean imágenes) y referencias
-# a entidades externas.
+# Sanitiza contenido SVG para embeberlo inline en HTML.
+#
+# Estrategia: allowlist estricto de tags y atributos (en vez de blocklist),
+# para cubrir vectores que el sanitizer anterior dejaba pasar:
+#   - <style> con @keyframes y url('javascript:...')
+#   - <foreignObject> con HTML embebido
+#   - <animate>/<set> con attributeName="href" to="javascript:..."
+#   - <use href="..."> con xlink a recursos externos
+#   - <image href="data:text/html,..."> y similares
 module SvgSanitizer
   module_function
 
-  DANGEROUS_TAGS = %w[script foreignobject].freeze
+  ALLOWED_TAGS = %w[
+    svg g defs symbol use view title desc metadata
+    path rect circle ellipse line polyline polygon
+    text tspan textpath
+    linearGradient radialGradient stop
+    clipPath mask pattern marker
+    filter feGaussianBlur feColorMatrix feComposite feOffset
+    feMerge feMergeNode feBlend feFlood feMorphology feTurbulence
+    feDisplacementMap feSpecularLighting feDiffuseLighting
+    feDistantLight fePointLight feSpotLight feImage feTile
+    feConvolveMatrix feComponentTransfer feFuncA feFuncR feFuncG feFuncB
+  ].map(&:downcase).to_set.freeze
+
+  EVENT_ATTR = /\Aon/i.freeze
   HREF_ATTRS = %w[href xlink:href].freeze
-  DANGEROUS_SCHEMES = %w[javascript: vbscript: data:].freeze
+
+  # Esquemas seguros para href/xlink:href. Cualquier otra cosa (incluyendo
+  # `javascript:`, `data:`, `vbscript:`, `file:`) se elimina.
+  SAFE_HREF = %r{
+    \A(?:
+      https?:// |
+      mailto: |
+      \# |          # fragmentos internos
+      / |           # rutas absolutas
+      \./ |
+      \.\./ |
+      [^:]*\z       # cualquier cosa sin esquema (path relativo)
+    )
+  }xi.freeze
 
   def sanitize(svg_content)
     return "" if svg_content.blank?
 
-    doc = Nokogiri::XML(svg_content) { |c| c.nononet.noent.nocdata }
-    root = doc.root
-    return "" unless root && root.name.casecmp("svg").zero?
+    fragment = Loofah.xml_fragment(svg_content)
+    fragment.scrub!(svg_scrubber)
 
-    strip_dangerous!(root)
+    root = fragment.children.find { |c| c.element? && c.name.casecmp("svg").zero? }
+    return "" unless root
+
     root.to_xml(save_with: Nokogiri::XML::Node::SaveOptions::AS_XML)
-  rescue Nokogiri::XML::SyntaxError
+  rescue Nokogiri::XML::SyntaxError, StandardError
     ""
   end
 
-  def strip_dangerous!(node)
-    node.traverse do |child|
-      next unless child.element?
+  def svg_scrubber
+    Loofah::Scrubber.new do |node|
+      next Loofah::Scrubber::CONTINUE unless node.element?
 
-      if DANGEROUS_TAGS.include?(child.name.downcase)
-        child.remove
-        next
+      unless ALLOWED_TAGS.include?(node.name.downcase)
+        node.remove
+        next Loofah::Scrubber::STOP
       end
 
-      child.attribute_nodes.each do |attr|
+      node.attribute_nodes.each do |attr|
         name = attr.name.to_s.downcase
-        if name.start_with?("on")
+
+        if name.match?(EVENT_ATTR)
           attr.remove
-        elsif HREF_ATTRS.include?(name) && dangerous_href?(attr.value)
+        elsif HREF_ATTRS.include?(name) && !SAFE_HREF.match?(attr.value.to_s.strip)
           attr.remove
         end
       end
-    end
-  end
 
-  def dangerous_href?(value)
-    value = value.to_s.strip.downcase
-    DANGEROUS_SCHEMES.any? { |s| value.start_with?(s) }
+      Loofah::Scrubber::CONTINUE
+    end
   end
 end


### PR DESCRIPTION
… SVG

Resuelve 5 hallazgos críticos del análisis de seguridad (C1-C4, C8):

- C1: reemplaza Project.find(params[:project_id]) por Project.for_user(current_user).find en 8 controllers (documents, folders, todos, tasks, announcements, announcement_comments, columns, comments). Users no-miembros reciben 404.
- C2: Task se carga desde @todo.tasks.find en tasks_controller y task_assignments_controller; extraído set_task para evitar re-asignaciones que pisaban el scoping.
- C3: Folder y parent_folder se cargan desde @project.folders.find en folders_controller y documents_controller.
- C4: Document se carga via join con project_users del current_user, cerrando download, duplicate, archive, show, edit, update, destroy.
- C8: SvgSanitizer reescrito con Loofah + scrubber allowlist estricto. Bloquea <style>, <foreignObject>, <animate href= javascript:>, <use xlink:href=javascript:> y otros vectores que el blocklist anterior dejaba pasar.

Extra: TaskAssignmentsController#create ahora valida que el assignee sea miembro del project (antes User.find permitía cualquier usuario).

Documento docs/analisis-de-vulnerabilidades.md incluye el reporte completo (25 hallazgos), tabla de estado y changelog.