### PR TITLE
fix: improve notification handling for file-only messages and prevent…

### DIFF
--- a/app/models/task_assignment.rb
+++ b/app/models/task_assignment.rb
@@ -4,14 +4,28 @@ class TaskAssignment < ApplicationRecord
   
   validates :user_id, uniqueness: { scope: :task_id }
 
-  after_create :send_assignment_notification
+  after_create :dispatch_notification
 
   private
 
-  def send_assignment_notification
+  def dispatch_notification
     return unless user&.email.present?
     return unless task&.todo&.project.present?
 
-    TaskAssignmentMailer.assignment_notification(self).deliver_later
+    NotificationDispatcher.call(
+      user: user,
+      notifiable: task,
+      notification_type: "task_assignment",
+      metadata: {
+        task_id: task.id,
+        task_title: task.title,
+        assigned_by: task.created_by&.full_name.presence || task.created_by&.email,
+        project_id: task.todo.project.id,
+        project_title: task.todo.project.title
+      },
+      mailer: TaskAssignmentMailer,
+      mailer_method: :assignment_notification,
+      mailer_args: [self]
+    )
   end
 end

--- a/app/services/chat/conversation_notifier.rb
+++ b/app/services/chat/conversation_notifier.rb
@@ -1,0 +1,43 @@
+# Notifies participants of a conversation (DM) about a new message.
+# Unlike channels, direct messages always generate a notification.
+# Uses NotificationDispatcher so push/email/ActionCable are all handled.
+module Chat
+  class ConversationNotifier
+    def self.call(message)
+      new(message).call
+    end
+
+    def initialize(message)
+      @message = message
+    end
+
+    def call
+      return unless @message.messageable.is_a?(Conversation)
+
+      conversation = @message.messageable
+      recipient = conversation.other_user_for(@message.user)
+      return if recipient.nil?
+      # Skip if the recipient was already notified via MentionDispatcher (chat_mention)
+      return if @message.message_mentions.exists?(user: recipient)
+
+      NotificationDispatcher.call(
+        user: recipient,
+        notifiable: @message,
+        notification_type: "direct_message",
+        metadata: notification_metadata
+      )
+    end
+
+    private
+
+    def notification_metadata
+      {
+        message_id: @message.id,
+        conversation_id: @message.messageable_id,
+        project_id: @message.project.id,
+        sender_name: @message.user.full_name.presence || @message.user.email,
+        preview: @message.body.to_s.strip.truncate(120).presence || "[Archivo adjunto]"
+      }
+    end
+  end
+end

--- a/app/services/chat/mention_dispatcher.rb
+++ b/app/services/chat/mention_dispatcher.rb
@@ -17,8 +17,7 @@ module Chat
 
       mentioned.each do |user|
         MessageMention.find_or_create_by!(message: @message, user: user)
-        notification = create_notification(user)
-        broadcast_notification(user, notification) if notification
+        dispatch_to(user)
       end
     end
 
@@ -28,15 +27,16 @@ module Chat
       @project ||= @message.project
     end
 
-    def create_notification(user)
-      Notification.create!(
+    def dispatch_to(user)
+      NotificationDispatcher.call(
         user: user,
         notifiable: @message,
         notification_type: "chat_mention",
-        metadata: notification_metadata
+        metadata: notification_metadata,
+        mailer: ChatMailer,
+        mailer_method: :new_message,
+        mailer_args: [user, @message]
       )
-    rescue ActiveRecord::RecordInvalid
-      nil
     end
 
     def notification_metadata
@@ -46,18 +46,8 @@ module Chat
         messageable_id: @message.messageable_id,
         project_id: project.id,
         mentioned_by: @message.user.full_name.presence || @message.user.email,
-        preview: @message.body.to_s.truncate(120)
+        preview: @message.body.to_s.strip.truncate(120).presence || "[Archivo adjunto]"
       }
-    end
-
-    def broadcast_notification(user, notification)
-      return unless defined?(NotificationsChannel)
-
-      NotificationsChannel.broadcast_to(user, {
-        action: "new",
-        notification_id: notification.id,
-        unread_count: user.notifications.unread.count
-      })
     end
   end
 end

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,87 @@
+<% meta = notification.metadata || {} %>
+<%= link_to notification_path(notification),
+    class: "block bg-white border rounded-lg p-4 hover:shadow-md transition-shadow #{notification.read? ? 'border-gray-200' : 'border-indigo-300 bg-indigo-50'}" do %>
+
+  <div class="flex items-start gap-3">
+    <% unless notification.read? %>
+      <div class="w-2 h-2 bg-indigo-600 rounded-full mt-2 flex-shrink-0"></div>
+    <% end %>
+
+    <div class="flex-1 min-w-0">
+      <% case notification.notification_type %>
+      <% when "mention" %>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-indigo-600 flex-shrink-0">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+            <circle cx="9" cy="7" r="4"/>
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+          </svg>
+          <span class="font-semibold text-gray-900"><%= meta['mentioned_by'] %></span>
+          <span class="text-gray-600">te mencionó en</span>
+          <span class="font-medium text-gray-900"><%= meta['task_title'] %></span>
+        </div>
+        <% if meta['comment_preview'].present? %>
+          <p class="text-sm text-gray-600 ml-7 truncate">"<%= meta['comment_preview'] %>"</p>
+        <% end %>
+
+      <% when "task_assignment" %>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-green-600 flex-shrink-0">
+            <path d="M9 11l3 3L22 4"/>
+            <path d="M21 12v7a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2h11"/>
+          </svg>
+          <span class="font-semibold text-gray-900"><%= meta['assigned_by'] %></span>
+          <span class="text-gray-600">te asignó la tarea</span>
+          <span class="font-medium text-gray-900"><%= meta['task_title'] %></span>
+        </div>
+        <p class="text-sm text-gray-600 ml-7">Proyecto: <%= meta['project_title'] %></p>
+
+      <% when "direct_message" %>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-purple-600 flex-shrink-0">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+          <span class="font-semibold text-gray-900"><%= meta['sender_name'] %></span>
+          <span class="text-gray-600">te envió un mensaje directo</span>
+        </div>
+        <% if meta['preview'].present? %>
+          <p class="text-sm text-gray-600 ml-7 truncate">"<%= meta['preview'] %>"</p>
+        <% else %>
+          <p class="text-sm text-gray-400 ml-7 italic">Archivo adjunto</p>
+        <% end %>
+
+      <% when "chat_mention" %>
+        <div class="flex items-center gap-2 mb-1 flex-wrap">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-orange-600 flex-shrink-0">
+            <path d="M12 20h9"/>
+            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>
+          </svg>
+          <span class="font-semibold text-gray-900"><%= meta['mentioned_by'] %></span>
+          <span class="text-gray-600">te mencionó en chat</span>
+        </div>
+        <% if meta['preview'].present? %>
+          <p class="text-sm text-gray-600 ml-7 truncate">"<%= meta['preview'] %>"</p>
+        <% end %>
+
+      <% else %>
+        <div class="flex items-center gap-2 mb-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-gray-600 flex-shrink-0">
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
+            <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+          </svg>
+          <span class="font-medium text-gray-900">Nueva notificación</span>
+        </div>
+        <% if meta['preview'].present? %>
+          <p class="text-sm text-gray-600 ml-7"><%= meta['preview'] %></p>
+        <% else %>
+          <p class="text-sm text-gray-400 ml-7 italic">Tienes una nueva notificación</p>
+        <% end %>
+      <% end %>
+
+      <p class="text-xs text-gray-500 ml-7 mt-2">
+        <%= time_ago_in_words(notification.created_at) %> atrás
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-between items-center mb-6">
     <h1 class="text-3xl font-bold text-gray-900">Notificaciones</h1>
     
-    <% if @notifications.unread.any? %>
+    <% if current_user.notifications.unread.any? %>
       <%= button_to "Marcar todas como leídas", 
           mark_all_as_read_notifications_path,
           method: :post,
@@ -10,44 +10,29 @@
     <% end %>
   </div>
 
+  <!-- Configuración de notificaciones push -->
+  <div data-push-notifications-target="settingsRow" class="hidden mb-6 bg-white border border-gray-200 rounded-xl p-4 flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <div class="p-2 bg-purple-50 rounded-lg">
+        <svg data-push-notifications-target="settingsIconOn" class="hidden w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"/></svg>
+        <svg data-push-notifications-target="settingsIconOff" class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.143 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
+      </div>
+      <div>
+        <h3 class="text-sm font-semibold text-gray-900">Notificaciones push</h3>
+        <p data-push-notifications-target="settingsText" class="text-xs text-gray-500">Recibí alertas incluso cuando no estés en la app</p>
+      </div>
+    </div>
+    <button type="button" data-action="click->push-notifications#toggle" class="flex items-center gap-2 cursor-pointer focus:outline-none">
+      <div data-push-notifications-target="track" class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent bg-gray-200 transition-colors duration-200 ease-in-out focus:ring-2 focus:ring-purple-600 focus:ring-offset-2">
+        <span data-push-notifications-target="knob" class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out translate-x-0"></span>
+      </div>
+    </button>
+  </div>
+
   <% if @notifications.any? %>
     <div class="space-y-2">
       <% @notifications.each do |notification| %>
-        <%= link_to notification_path(notification), 
-            class: "block bg-white border rounded-lg p-4 hover:shadow-md transition-shadow #{notification.read? ? 'border-gray-200' : 'border-indigo-300 bg-indigo-50'}" do %>
-          
-          <div class="flex items-start gap-3">
-            <% if !notification.read? %>
-              <div class="w-2 h-2 bg-indigo-600 rounded-full mt-2"></div>
-            <% end %>
-            
-            <div class="flex-1">
-              <div class="flex items-center gap-2 mb-1">
-                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-indigo-600">
-                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
-                  <circle cx="9" cy="7" r="4"/>
-                  <path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
-                  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
-                </svg>
-                <span class="font-semibold text-gray-900">
-                  <%= notification.metadata['mentioned_by'] %>
-                </span>
-                <span class="text-gray-600">te mencionó en</span>
-                <span class="font-medium text-gray-900">
-                  <%= notification.metadata['task_title'] %>
-                </span>
-              </div>
-              
-              <p class="text-sm text-gray-600 ml-7">
-                "<%= notification.metadata['comment_preview'] %>"
-              </p>
-              
-              <p class="text-xs text-gray-500 ml-7 mt-2">
-                <%= time_ago_in_words(notification.created_at) %> atrás
-              </p>
-            </div>
-          </div>
-        <% end %>
+        <%= render "notifications/notification", notification: notification %>
       <% end %>
     </div>
 


### PR DESCRIPTION
… duplicates

Several improvements to notification display and dispatch logic:

- Add nil-safety for notification metadata in the notification partial by defaulting to empty hash when metadata is missing
- Fix empty preview rendering for file-only messages by stripping whitespace and applying presence check, falling back to "[Archivo adjunto]" text
- Add `.present?` guards for preview rendering in notification partial to prevent empty quote marks
- Add layout robustness with flex-shrink-0 and min-w-0 classes to prevent text overflow issues in notifications
- Skip direct_message notification if recipient was already notified via MentionDispatcher, preventing duplicate notifications when user is @mentioned in a DM
- Fix notifications index page to use current_user.notifications.unread.any? instead of @notifications.unread.any? (which was Kaminari-paginated)
- Add `.presence` to TaskAssignment full_name fallback so users without first/last name properly fall back to email instead of blank space
- Consolidate TaskAssignment notification dispatch through NotificationDispatcher instead of direct mailer call for consistency with other notification types